### PR TITLE
Fix broken FPIC compiler test in aarch64 build

### DIFF
--- a/org.freedesktop.Sdk.Extension.llvm12.json
+++ b/org.freedesktop.Sdk.Extension.llvm12.json
@@ -39,8 +39,8 @@
       "build-options": {
         "arch": {
           "aarch64": {
-            "cflags": "-fPIC",
-            "cxxflags": "-fPIC",
+            "cflags": "-Qunused-arguments",
+            "cxxflags": "-Qunused-arguments",
             "config-opts": [
               "-DFFI_INCLUDE_DIR=/usr/lib/aarch64-linux-gnu/libffi-3.2.1/include",
               "-DLLVM_DEFAULT_TARGET_TRIPLE=aarch64-unknown-linux-gnu",


### PR DESCRIPTION
cmake test -fPIC support by appending it to existing cflags. The default cflags set contains -fstack-clash-protection which isn't supported for aarch64 and misleads cmake that compiler doesn't support -fPIC while it does.