### PR TITLE
[20.08] Ensure the compiled binaries use the correct library location

### DIFF
--- a/org.freedesktop.Sdk.Extension.llvm12.json
+++ b/org.freedesktop.Sdk.Extension.llvm12.json
@@ -61,7 +61,7 @@
           "CC": "clang",
           "CXX": "clang++"
         },
-        "ldflags": "-fuse-ld=lld"
+        "ldflags": "-fuse-ld=lld -Wl,--disable-new-dtags"
       },
       "config-opts": [
         "-DLLVM_ENABLE_PROJECTS='clang;clang-tools-extra;compiler-rt;lld;lldb'",


### PR DESCRIPTION
Backport of https://github.com/flathub/org.freedesktop.Sdk.Extension.llvm12/commit/48891f4faadb8aac5912865cd9d825c8f3cea8ba